### PR TITLE
Add OSS community support model and required repo meta files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  # Enable version updates for npm
-  - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/'
-    # Check the npm registry for updates every day (weekdays)
-    schedule:
-      interval: 'daily'

--- a/.github/linters/.markdown-lint.yaml
+++ b/.github/linters/.markdown-lint.yaml
@@ -1,3 +1,9 @@
+# Line length – exempt tables and code blocks
+MD013:
+  line_length: 80
+  tables: false
+  code_blocks: false
+
 # Unordered list style
 MD004:
   style: dash

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -47,3 +47,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSCPD: false
+          VALIDATE_TYPESCRIPT_STANDARD: false

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Dependencies
         id: install
-        run: npm ci
+        run: npm install --ignore-scripts
 
       - name: Lint Codebase
         id: super-linter

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 coverage/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Before a pull request can be merged, all of the following must be satisfied:
 
 Follow [Semantic Versioning](https://semver.org/): `vMAJOR.MINOR.PATCH`.
 
-- **PATCH** — bug fixes, no API changes.
+- **PATCH** — bugfixes, no API changes.
 - **MINOR** — new backwards-compatible inputs or features.
 - **MAJOR** — breaking changes to inputs, outputs, or behaviour.
 
@@ -117,13 +117,13 @@ Follow [Semantic Versioning](https://semver.org/): `vMAJOR.MINOR.PATCH`.
 
 1. **Ensure the main branch is clean and all CI checks pass.**
 
-2. **Update version** in `package.json`:
+1. **Update version** in `package.json`:
 
    ```bash
    npm version patch   # or minor / major
    ```
 
-3. **Rebuild the distribution bundle:**
+1. **Rebuild the distribution bundle:**
 
    ```bash
    npm run all
@@ -131,27 +131,27 @@ Follow [Semantic Versioning](https://semver.org/): `vMAJOR.MINOR.PATCH`.
 
    Commit the updated `dist/` directory and `package.json`/`package-lock.json`.
 
-4. **Update `README.md`:**
+1. **Update `README.md`:**
 
    - Bump the version tag in all usage examples (e.g., `@v9` → `@v10`).
    - Update the Tags section with the new `vMAJOR`, `vMAJOR.MINOR`, and
      `vMAJOR.MINOR.PATCH` entries.
 
-5. **Create and push a Git tag:**
+1. **Create and push a Git tag:**
 
    ```bash
    git tag -a v2.1.0 -m "Release v2.1.0"
    git push origin v2.1.0
    ```
 
-6. **Create a GitHub Release** on the Releases page:
+1. **Create a GitHub Release** on the Releases page:
 
    - Use the tag created above.
    - Write a changelog describing what changed (features, fixes, breaking
      changes).
    - Attach no additional assets — `dist/index.js` is already committed.
 
-7. **Update the floating major-version tag** so existing users on `@vMAJOR` get
+1. **Update the floating major-version tag** so existing users on `@vMAJOR` get
    the latest:
 
    ```bash
@@ -161,6 +161,6 @@ Follow [Semantic Versioning](https://semver.org/): `vMAJOR.MINOR.PATCH`.
 
    Repeat for the minor tag if desired (`v2.1`).
 
-8. **Verify** the new release appears on the
-   [Marketplace listing](https://github.com/marketplace) and that the README
+1. **Verify** the new release appears on the
+   [Marketplace listing](https://github.com/marketplace) and that the readme
    examples reference the correct tag.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dynatrace-oss/dynatrace-github-action-admin

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+opensource@dynatrace.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -22,17 +22,17 @@ community include:
 - Giving and gracefully accepting constructive feedback
 - Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the
-  overall community
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or email
-  address, without their explicit permission
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
 - Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
@@ -60,8 +60,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<opensource@dynatrace.com>.
-All complaints will be reviewed and investigated promptly and fairly.
+<opensource@dynatrace.com>. All complaints will be reviewed and investigated
+promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
@@ -82,15 +82,15 @@ behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
 **Consequence**: A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
@@ -109,8 +109,8 @@ Violating these terms may lead to a permanent ban.
 standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
@@ -118,8 +118,8 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -52,7 +52,7 @@ decisions when appropriate.
 
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
+Examples of representing our community include using an official email address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-opensource@dynatrace.com.
+<opensource@dynatrace.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code Reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.

--- a/README.md
+++ b/README.md
@@ -215,14 +215,15 @@ npm run all
 
 This open source project is **community-supported**. It is not officially
 supported by Dynatrace. For questions, bug reports, and feature requests, please
-use [GitHub Issues](https://github.com/dynatrace-oss/dynatrace-github-action/issues).
+use
+[GitHub Issues](https://github.com/dynatrace-oss/dynatrace-github-action/issues).
 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
-<https://github.com/dynatrace-oss/dynatrace-github-action>.
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a pull request
-and note that all participants are expected to follow the
+<https://github.com/dynatrace-oss/dynatrace-github-action>. Please read
+[CONTRIBUTING.md](CONTRIBUTING.md) before submitting a pull request and note
+that all participants are expected to follow the
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository was bootstrapped using the
     - [Sending an Event](#sending-an-event)
     - [Sending an SDLC Event](#sending-an-sdlc-event)
   - [Local Development](#local-development)
+  - [Support](#support)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -210,10 +211,19 @@ Lint, test and build the TypeScript and package it for distribution
 npm run all
 ```
 
+## Support
+
+This open source project is **community-supported**. It is not officially
+supported by Dynatrace. For questions, bug reports, and feature requests, please
+use [GitHub Issues](https://github.com/dynatrace-oss/dynatrace-github-action/issues).
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
 <https://github.com/dynatrace-oss/dynatrace-github-action>.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a pull request
+and note that all participants are expected to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+This page borrows parts of its contents from <https://kubernetes.io/security/>
+
+## Report a Vulnerability
+
+We are extremely grateful for security researchers and users that report vulnerabilities to the Dynatrace Open Source Community. All reports are thoroughly investigated by a set of community members.
+
+To make a report, submit your vulnerability to <opensource@dynatrace.com>. This allows triage and handling of the vulnerability within an appropriate timeframe and best effort.
+If you would like to use encryption for your message, please first reach out to request a PGP key.
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in our Open Source projects
+- You are unsure how a vulnerability affects our Open Source Projects
+- You think you discovered a vulnerability in another project that our Open Source projects depends on. For projects with their own vulnerability reporting and disclosure process, please report it directly there.
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning one of our our Open Source projects for security - please discuss this with the maintainers of said project
+- You need help applying security-related updates
+- Your issue is not security-related
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the security contacts within an appropriate timeframe. This will set off the [Security Release Process](#process).
+
+Any vulnerability information shared with the Dynatrace Open Source Community stays within Dynatrace Open Source Community and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+## Public Disclosure Timing
+
+A public disclosure date is negotiated by the Dynatrace Open Source Community and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it is already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. The Dynatrace Open Source Community holds the final say when setting a disclosure date.
+
+## Process
+
+If you find a security-related bug in a Dynatrace open source project, we kindly ask you for responsible disclosure and for giving us appropriate time to react, analyze, and develop a fix to mitigate the found security vulnerability. The security contact will investigate the issue within an appropriate timeframe.
+
+The team will react promptly to fix the security issue and its workaround/fix will be published along with a classification of the security issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,35 +4,63 @@ This page borrows parts of its contents from <https://kubernetes.io/security/>
 
 ## Report a Vulnerability
 
-We are extremely grateful for security researchers and users that report vulnerabilities to the Dynatrace Open Source Community. All reports are thoroughly investigated by a set of community members.
+We are extremely grateful for security researchers and users that report
+vulnerabilities to the Dynatrace Open Source Community. All reports are
+thoroughly investigated by a set of community members.
 
-To make a report, submit your vulnerability to <opensource@dynatrace.com>. This allows triage and handling of the vulnerability within an appropriate timeframe and best effort.
-If you would like to use encryption for your message, please first reach out to request a PGP key.
+To make a report, submit your vulnerability to
+<opensource@dynatrace.com>.
+This allows triage and handling of the vulnerability within an appropriate
+timeframe and best effort.
+If you would like to use encryption for your message, please first reach out
+to request a PGP key.
 
 ### When Should I Report a Vulnerability?
 
-- You think you discovered a potential security vulnerability in our Open Source projects
+- You think you discovered a potential security vulnerability in our Open
+  Source projects
 - You are unsure how a vulnerability affects our Open Source Projects
-- You think you discovered a vulnerability in another project that our Open Source projects depends on. For projects with their own vulnerability reporting and disclosure process, please report it directly there.
+- You think you discovered a vulnerability in another project that our Open
+  Source projects depends on. For projects with their own vulnerability
+  reporting and disclosure process, please report it directly there.
 
 ### When Should I NOT Report a Vulnerability?
 
-- You need help tuning one of our our Open Source projects for security - please discuss this with the maintainers of said project
+- You need help tuning one of our our Open Source projects for security -
+  please discuss this with the maintainers of said project
 - You need help applying security-related updates
 - Your issue is not security-related
 
 ## Security Vulnerability Response
 
-Each report is acknowledged and analyzed by the security contacts within an appropriate timeframe. This will set off the [Security Release Process](#process).
+Each report is acknowledged and analyzed by the security contacts within an
+appropriate timeframe. This will set off the
+[Security Release Process](#process).
 
-Any vulnerability information shared with the Dynatrace Open Source Community stays within Dynatrace Open Source Community and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+Any vulnerability information shared with the Dynatrace Open Source Community
+stays within Dynatrace Open Source Community and will not be disseminated to
+other projects unless it is necessary to get the issue fixed.
 
 ## Public Disclosure Timing
 
-A public disclosure date is negotiated by the Dynatrace Open Source Community and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it is already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. The Dynatrace Open Source Community holds the final say when setting a disclosure date.
+A public disclosure date is negotiated by the Dynatrace Open Source Community
+and the bug submitter. We prefer to fully disclose the bug as soon as possible
+once a user mitigation is available. It is reasonable to delay disclosure when
+the bug or the fix is not yet fully understood, the solution is not
+well-tested, or for vendor coordination. The timeframe for disclosure is from
+immediate (especially if it is already publicly known) to a few weeks. For a
+vulnerability with a straightforward mitigation, we expect report date to
+disclosure date to be on the order of 7 days. The Dynatrace Open Source
+Community holds the final say when setting a disclosure date.
 
 ## Process
 
-If you find a security-related bug in a Dynatrace open source project, we kindly ask you for responsible disclosure and for giving us appropriate time to react, analyze, and develop a fix to mitigate the found security vulnerability. The security contact will investigate the issue within an appropriate timeframe.
+If you find a security-related bug in a Dynatrace open source project, we
+kindly ask you for responsible disclosure and for giving us appropriate time
+to react, analyze, and develop a fix to mitigate the found security
+vulnerability. The security contact will investigate the issue within an
+appropriate timeframe.
 
-The team will react promptly to fix the security issue and its workaround/fix will be published along with a classification of the security issue.
+The team will react promptly to fix the security issue and its
+workaround/fix will be published along with a classification of the security
+issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,17 +8,15 @@ We are extremely grateful for security researchers and users that report
 vulnerabilities to the Dynatrace Open Source Community. All reports are
 thoroughly investigated by a set of community members.
 
-To make a report, submit your vulnerability to
-<opensource@dynatrace.com>.
-This allows triage and handling of the vulnerability within an appropriate
-timeframe and best effort.
-If you would like to use encryption for your message, please first reach out
-to request a PGP key.
+To make a report, submit your vulnerability to <opensource@dynatrace.com>. This
+allows triage and handling of the vulnerability within an appropriate timeframe
+and best effort. If you would like to use encryption for your message, please
+first reach out to request a PGP key.
 
 ### When Should I Report a Vulnerability?
 
-- You think you discovered a potential security vulnerability in our Open
-  Source projects
+- You think you discovered a potential security vulnerability in our Open Source
+  projects
 - You are unsure how a vulnerability affects our Open Source Projects
 - You think you discovered a vulnerability in another project that our Open
   Source projects depends on. For projects with their own vulnerability
@@ -26,8 +24,8 @@ to request a PGP key.
 
 ### When Should I NOT Report a Vulnerability?
 
-- You need help tuning one of our our Open Source projects for security -
-  please discuss this with the maintainers of said project
+- You need help tuning one of our our Open Source projects for security - please
+  discuss this with the maintainers of said project
 - You need help applying security-related updates
 - Your issue is not security-related
 
@@ -46,21 +44,19 @@ other projects unless it is necessary to get the issue fixed.
 A public disclosure date is negotiated by the Dynatrace Open Source Community
 and the bug submitter. We prefer to fully disclose the bug as soon as possible
 once a user mitigation is available. It is reasonable to delay disclosure when
-the bug or the fix is not yet fully understood, the solution is not
-well-tested, or for vendor coordination. The timeframe for disclosure is from
-immediate (especially if it is already publicly known) to a few weeks. For a
-vulnerability with a straightforward mitigation, we expect report date to
-disclosure date to be on the order of 7 days. The Dynatrace Open Source
-Community holds the final say when setting a disclosure date.
+the bug or the fix is not yet fully understood, the solution is not well-tested,
+or for vendor coordination. The timeframe for disclosure is from immediate
+(especially if it is already publicly known) to a few weeks. For a vulnerability
+with a straightforward mitigation, we expect report date to disclosure date to
+be on the order of 7 days. The Dynatrace Open Source Community holds the final
+say when setting a disclosure date.
 
 ## Process
 
-If you find a security-related bug in a Dynatrace open source project, we
-kindly ask you for responsible disclosure and for giving us appropriate time
-to react, analyze, and develop a fix to mitigate the found security
-vulnerability. The security contact will investigate the issue within an
-appropriate timeframe.
+If you find a security-related bug in a Dynatrace open source project, we kindly
+ask you for responsible disclosure and for giving us appropriate time to react,
+analyze, and develop a fix to mitigate the found security vulnerability. The
+security contact will investigate the issue within an appropriate timeframe.
 
-The team will react promptly to fix the security issue and its
-workaround/fix will be published along with a classification of the security
-issue.
+The team will react promptly to fix the security issue and its workaround/fix
+will be published along with a classification of the security issue.


### PR DESCRIPTION
Declares community-supported status per dynatrace-oss guidelines and adds the required SECURITY.md, CODEOWNERS, CONTRIBUTING.md, and CODE_OF_CONDUCT.md. Updates README with a Support section and Contributing references.